### PR TITLE
feat(storage): Add image cache management and Storage settings page

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -49,6 +49,9 @@ export const PHOTOSET_MARK_UPLOADED = `${PHOTOSET_CHANNEL}:markUploaded`;
 
 export const PHOTOSETS_DIR = 'photosets';
 
+export const CACHE_CHANNEL = 'cache';
+export const CACHE_GET_USAGE = `${CACHE_CHANNEL}:getUsage`;
+
 export const IMAGE_PROCESSOR_CHANNEL = 'image-processor';
 export const IMAGE_PROCESSOR_RESIZE = `${IMAGE_PROCESSOR_CHANNEL}:resize`;
 export const IMAGE_PROCESSOR_PROGRESS = `${IMAGE_PROCESSOR_CHANNEL}:progress`;

--- a/src/main/drivers/image-processor.ts
+++ b/src/main/drivers/image-processor.ts
@@ -40,13 +40,6 @@ async function processImage(
     `"${name}": ${width}x${height} ${inputFormat}, ${(inputBuffer.byteLength / 1024).toFixed(1)} KB, id=${id}`,
   );
 
-  // Rename the original file with its format
-  const originalOutputPath = path.join(outputFolder, `${name}_original.${inputFormat}`);
-
-  if (!dryRun) {
-    fs.copyFileSync(imagePath, originalOutputPath);
-  }
-
   const imagePaths: ProcessedImage['imagePaths'] = [];
 
   for (const res of [128, 640, 1280, 2880]) {

--- a/src/main/listeners/__tests__/cache.test.ts
+++ b/src/main/listeners/__tests__/cache.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getCacheUsage } from '@/main/listeners/cache';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nubes-cache-test-'));
+});
+
+afterEach(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('getCacheUsage', () => {
+  it('returns correct totals for a directory with files', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'a.jpg'), Buffer.alloc(1024));
+    fs.writeFileSync(path.join(tmpDir, 'b.webp'), Buffer.alloc(2048));
+
+    const usage = await getCacheUsage(tmpDir);
+    expect(usage.totalBytes).toBe(3072);
+    expect(usage.fileCount).toBe(2);
+  });
+
+  it('returns zeros when directory does not exist', async () => {
+    const usage = await getCacheUsage(path.join(tmpDir, 'nonexistent'));
+    expect(usage.totalBytes).toBe(0);
+    expect(usage.fileCount).toBe(0);
+  });
+
+  it('counts files in nested subdirectories', async () => {
+    const subDir = path.join(tmpDir, 'sub');
+    fs.mkdirSync(subDir);
+    fs.writeFileSync(path.join(tmpDir, 'root.jpg'), Buffer.alloc(500));
+    fs.writeFileSync(path.join(subDir, 'nested.jpg'), Buffer.alloc(300));
+
+    const usage = await getCacheUsage(tmpDir);
+    expect(usage.totalBytes).toBe(800);
+    expect(usage.fileCount).toBe(2);
+  });
+});

--- a/src/main/listeners/__tests__/photoset.test.ts
+++ b/src/main/listeners/__tests__/photoset.test.ts
@@ -1,3 +1,8 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
 import { eq } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
@@ -5,6 +10,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type * as schema from '@/common/db/schema';
 import { photosetImageOutputs, photosetImages, photosets } from '@/common/db/schema';
 import { createTestDb } from '@/main/__test-utils__/db';
+import { deleteFiles, getPhotosetFilePaths } from '@/main/listeners/photoset';
 
 let db: BetterSQLite3Database<typeof schema>;
 let close: () => void;
@@ -263,5 +269,84 @@ describe('publish and markUploaded', () => {
       .all();
 
     expect(rows[0].uploadedAt).toBeTruthy();
+  });
+});
+
+describe('delete cleans up files', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nubes-test-'));
+  });
+
+  function createTempFile(name: string, size: number): string {
+    const filePath = path.join(tmpDir, name);
+    fs.writeFileSync(filePath, Buffer.alloc(size, 'x'));
+    return filePath;
+  }
+
+  it('collects original + output paths for a photoset', () => {
+    const origPath = createTempFile('orig.jpg', 100);
+    const outPath = createTempFile('out_640.jpg', 50);
+
+    const ps = createPhotoset();
+    addImages(ps.id, [
+      {
+        name: 'photo.jpg',
+        originalPath: origPath,
+        outputs: [
+          { imagePath: outPath, type: 'jpg', resolution: 640, byteLength: 50 },
+        ],
+      },
+    ]);
+
+    const paths = getPhotosetFilePaths(db, ps.id);
+    expect(paths).toContain(origPath);
+    expect(paths).toContain(outPath);
+    expect(paths).toHaveLength(2);
+  });
+
+  it('deletes image files from disk', async () => {
+    const origPath = createTempFile('orig.jpg', 100);
+    const outPath = createTempFile('out_640.jpg', 50);
+
+    expect(fs.existsSync(origPath)).toBe(true);
+    expect(fs.existsSync(outPath)).toBe(true);
+
+    await deleteFiles([origPath, outPath]);
+
+    expect(fs.existsSync(origPath)).toBe(false);
+    expect(fs.existsSync(outPath)).toBe(false);
+  });
+
+  it('ignores missing files gracefully', async () => {
+    const missingPath = path.join(tmpDir, 'does-not-exist.jpg');
+    await expect(deleteFiles([missingPath])).resolves.toBeUndefined();
+  });
+
+  it('only deletes files for the targeted photoset', async () => {
+    const file1 = createTempFile('ps1_orig.jpg', 100);
+    const file2 = createTempFile('ps2_orig.jpg', 100);
+
+    const ps1 = createPhotoset({ name: 'Set 1' });
+    addImages(ps1.id, [
+      { name: 'a.jpg', originalPath: file1, outputs: [] },
+    ]);
+
+    const ps2 = createPhotoset({ name: 'Set 2' });
+    addImages(ps2.id, [
+      { name: 'b.jpg', originalPath: file2, outputs: [] },
+    ]);
+
+    // Delete only ps1's files
+    const paths = getPhotosetFilePaths(db, ps1.id);
+    await deleteFiles(paths);
+    db.delete(photosets).where(eq(photosets.id, ps1.id)).run();
+
+    expect(fs.existsSync(file1)).toBe(false);
+    expect(fs.existsSync(file2)).toBe(true);
+
+    // Cleanup
+    await fsp.rm(tmpDir, { recursive: true, force: true });
   });
 });

--- a/src/main/listeners/cache.ts
+++ b/src/main/listeners/cache.ts
@@ -1,0 +1,51 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+import { app } from 'electron';
+
+import { CACHE_GET_USAGE, PHOTOSETS_DIR } from '@/common/constants';
+import { handle } from '@/main/ipc';
+
+export interface CacheUsage {
+  totalBytes: number;
+  fileCount: number;
+}
+
+/**
+ * Recursively walk a directory and sum file sizes.
+ * Returns zeros if the directory doesn't exist.
+ */
+export async function getCacheUsage(dirPath: string): Promise<CacheUsage> {
+  let totalBytes = 0;
+  let fileCount = 0;
+
+  try {
+    const entries = await fsp.readdir(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        const sub = await getCacheUsage(fullPath);
+        totalBytes += sub.totalBytes;
+        fileCount += sub.fileCount;
+      } else if (entry.isFile()) {
+        const stat = await fsp.stat(fullPath);
+        totalBytes += stat.size;
+        fileCount += 1;
+      }
+    }
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { totalBytes: 0, fileCount: 0 };
+    }
+    throw err;
+  }
+
+  return { totalBytes, fileCount };
+}
+
+export function addCacheEventListeners() {
+  handle(CACHE_GET_USAGE, () => {
+    const photosetsDir = path.join(app.getPath('userData'), PHOTOSETS_DIR);
+    return getCacheUsage(photosetsDir);
+  });
+}

--- a/src/main/listeners/index.ts
+++ b/src/main/listeners/index.ts
@@ -1,5 +1,6 @@
 import type { BrowserWindow } from 'electron';
 
+import { addCacheEventListeners } from './cache';
 import { addDebugEventListeners } from './debug';
 import { addImagePickerEventListeners } from './image-picker';
 import { addImageProcessorEventListeners } from './image-processor';
@@ -10,6 +11,7 @@ import { addTrpcEventListeners } from './trpc';
 
 export function registerListeners(mainWindow: BrowserWindow) {
   // Register listeners here
+  addCacheEventListeners();
   addDebugEventListeners();
   addImagePickerEventListeners();
   addPhotosetEventListeners();

--- a/src/main/listeners/photoset.ts
+++ b/src/main/listeners/photoset.ts
@@ -1,4 +1,6 @@
-import { eq } from 'drizzle-orm';
+import fsp from 'node:fs/promises';
+
+import { eq, inArray } from 'drizzle-orm';
 
 import {
   PHOTOSET_ADD_IMAGES,
@@ -23,6 +25,52 @@ import { handle } from '@/main/ipc';
 
 function getDb() {
   return Database.instance.db;
+}
+
+/** Collect all file paths (originals + outputs) for a photoset. */
+export function getPhotosetFilePaths(
+  db: ReturnType<typeof getDb>,
+  photosetId: number,
+): string[] {
+  const images = db
+    .select({ originalPath: photosetImages.originalPath })
+    .from(photosetImages)
+    .where(eq(photosetImages.photosetId, photosetId))
+    .all();
+
+  const imageIds = images.length > 0
+    ? db
+        .select({ id: photosetImages.id })
+        .from(photosetImages)
+        .where(eq(photosetImages.photosetId, photosetId))
+        .all()
+        .map((r) => r.id)
+    : [];
+
+  const outputs =
+    imageIds.length > 0
+      ? db
+          .select({ imagePath: photosetImageOutputs.imagePath })
+          .from(photosetImageOutputs)
+          .where(inArray(photosetImageOutputs.imageId, imageIds))
+          .all()
+      : [];
+
+  return [
+    ...images.map((r) => r.originalPath),
+    ...outputs.map((r) => r.imagePath),
+  ];
+}
+
+/** Delete files from disk, ignoring ENOENT for already-missing files. */
+export async function deleteFiles(filePaths: string[]): Promise<void> {
+  await Promise.all(
+    filePaths.map((p) =>
+      fsp.unlink(p).catch((err: NodeJS.ErrnoException) => {
+        if (err.code !== 'ENOENT') throw err;
+      }),
+    ),
+  );
 }
 
 export function addPhotosetEventListeners() {
@@ -75,8 +123,10 @@ export function addPhotosetEventListeners() {
     return rows[0];
   });
 
-  handle(PHOTOSET_DELETE, photosetIdArgsSchema, (_, args) => {
+  handle(PHOTOSET_DELETE, photosetIdArgsSchema, async (_, args) => {
     const db = getDb();
+    const filePaths = getPhotosetFilePaths(db, args.id);
+    await deleteFiles(filePaths);
     db.delete(photosets).where(eq(photosets.id, args.id)).run();
   });
 

--- a/src/preload/cache.ts
+++ b/src/preload/cache.ts
@@ -1,0 +1,6 @@
+import { CACHE_GET_USAGE } from '@common';
+import { ipcRenderer } from 'electron';
+
+export const cache: CacheContext = {
+  getUsage: () => ipcRenderer.invoke(CACHE_GET_USAGE),
+};

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge } from 'electron';
 import { exposeElectronTRPC } from 'electron-trpc/main';
 
+import { cache } from './cache';
 import { debug } from './debug';
 import { imagePicker } from './image-picker';
 import { imageProcessor } from './image-processor';
@@ -8,6 +9,7 @@ import { photosets } from './photoset';
 import { storage } from './storage';
 import { theme } from './theme';
 
+contextBridge.exposeInMainWorld('cache', cache);
 contextBridge.exposeInMainWorld('storage', storage);
 contextBridge.exposeInMainWorld('themeMode', theme);
 contextBridge.exposeInMainWorld('imagePicker', imagePicker);

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { Link, Outlet, useLocation } from 'react-router-dom';
 const links = [
   { name: 'General', href: '/settings' },
   { name: 'Cameras', href: '/settings/cameras' },
+  { name: 'Storage', href: '/settings/storage' },
 ];
 
 export const Settings = () => {

--- a/src/renderer/pages/StorageSettings.tsx
+++ b/src/renderer/pages/StorageSettings.tsx
@@ -1,0 +1,197 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@client/components/ui/alert-dialog';
+import { Button } from '@client/components/ui/button';
+import { Skeleton } from '@client/components/ui/skeleton';
+import { HardDrive, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+import { formatBytes, formatDate } from './PhotosetDetail/utils';
+
+type PhotosetRow = Awaited<ReturnType<Window['photosets']['list']>>[number];
+
+interface CacheUsage {
+  totalBytes: number;
+  fileCount: number;
+}
+
+export const StorageSettings = () => {
+  const [usage, setUsage] = useState<CacheUsage | null>(null);
+  const [photosets, setPhotosets] = useState<PhotosetRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deleting, setDeleting] = useState<number | null>(null);
+  const [deletingAll, setDeletingAll] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [u, ps] = await Promise.all([
+        window.cache.getUsage(),
+        window.photosets.list({ sortBy: 'createdAt', sortOrder: 'desc' }),
+      ]);
+      setUsage(u);
+      setPhotosets(ps.filter((p) => p.uploadedAt));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleDelete = async (id: number) => {
+    setDeleting(id);
+    try {
+      await window.photosets.delete({ id });
+      await refresh();
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const handleDeleteAll = async () => {
+    setDeletingAll(true);
+    try {
+      await Promise.all(photosets.map((p) => window.photosets.delete({ id: p.id })));
+      await refresh();
+    } finally {
+      setDeletingAll(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-6">
+      {/* Cache overview */}
+      <div className="rounded-lg border p-6">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+            <HardDrive className="h-5 w-5 text-muted-foreground" />
+          </div>
+          <div>
+            <h3 className="text-sm font-medium">Image Cache</h3>
+            {loading ? (
+              <Skeleton className="mt-1 h-4 w-32" />
+            ) : usage ? (
+              <p className="text-sm text-muted-foreground">
+                {formatBytes(usage.totalBytes)} across {usage.fileCount}{' '}
+                {usage.fileCount === 1 ? 'file' : 'files'}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {/* Uploaded photosets list */}
+      <div className="rounded-lg border">
+        <div className="flex items-center justify-between border-b px-6 py-4">
+          <div>
+            <h3 className="text-sm font-medium">Uploaded Photosets</h3>
+            <p className="text-xs text-muted-foreground">
+              These photosets have been uploaded and their local cache can be
+              safely deleted.
+            </p>
+          </div>
+          {photosets.length > 0 && (
+            <AlertDialog>
+              <AlertDialogTrigger
+                render={
+                  <Button variant="destructive" size="sm" disabled={deletingAll} />
+                }
+              >
+                {deletingAll ? 'Deleting...' : 'Delete All'}
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete all uploaded photosets?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently delete {photosets.length} uploaded{' '}
+                    {photosets.length === 1 ? 'photoset' : 'photosets'} and
+                    their cached images from disk. This cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction variant="destructive" onClick={handleDeleteAll}>
+                    Delete All
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+        </div>
+
+        {loading ? (
+          <div className="space-y-3 p-6">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : photosets.length === 0 ? (
+          <p className="p-6 text-center text-sm text-muted-foreground">
+            No uploaded photosets to clean up.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {photosets.map((ps) => (
+              <li
+                key={ps.id}
+                className="flex items-center justify-between px-6 py-3"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{ps.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {ps.images.length}{' '}
+                    {ps.images.length === 1 ? 'image' : 'images'}
+                    {ps.uploadedAt && (
+                      <> &middot; Uploaded {formatDate(ps.uploadedAt)}</>
+                    )}
+                  </p>
+                </div>
+                <AlertDialog>
+                  <AlertDialogTrigger
+                    render={
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={deleting === ps.id}
+                      />
+                    }
+                  >
+                    <Trash2 className="h-4 w-4 text-muted-foreground" />
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Delete "{ps.name}"?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This will permanently delete this photoset and its
+                        cached images from disk. The uploaded version in S3 is
+                        not affected.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        variant="destructive"
+                        onClick={() => handleDelete(ps.id)}
+                      >
+                        Delete
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/routes.tsx
+++ b/src/renderer/routes.tsx
@@ -12,6 +12,7 @@ import { PhotosetDetail } from './pages/PhotosetDetail';
 import { S3Summary } from './pages/S3Summary';
 import { S3Upload } from './pages/S3Upload';
 import { Settings } from './pages/Settings';
+import { StorageSettings } from './pages/StorageSettings';
 
 export const router = createHashRouter(
   createRoutesFromElements(
@@ -27,6 +28,7 @@ export const router = createHashRouter(
       <Route path="settings" element={<Settings />}>
         <Route index element={<GeneralSettings />} />
         <Route path="cameras" element={<CameraSettings />} />
+        <Route path="storage" element={<StorageSettings />} />
       </Route>
     </Route>
   )

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -68,6 +68,10 @@ declare global {
     markUploaded: (args: { id: number }) => Promise<Photoset>;
   }
 
+  interface CacheContext {
+    getUsage: () => Promise<{ totalBytes: number; fileCount: number }>;
+  }
+
   interface DebugContext {
     setMockS3: (enabled: boolean) => Promise<void>;
     isMockS3: () => Promise<boolean>;
@@ -84,6 +88,7 @@ declare global {
     imagePicker: ImagePickerContext;
     imageProcessor: ImageProcessorContext;
     photosets: PhotosetContext;
+    cache: CacheContext;
     debug?: DebugContext;
   }
 }


### PR DESCRIPTION
## Context

Processed images (9 files per input image) are written to
`{userData}/photosets/` but never cleaned up. Deleting a photoset
only removed DB rows via cascade — files stayed on disk silently
eating space. Additionally, the image processor was copying
originals as `_original.{ext}` files that were never uploaded or
tracked in the DB.

## Solution

- `PHOTOSET_DELETE` now queries all file paths (originals + outputs)
  from the DB and deletes them from disk before cascade-deleting
  the DB row. ENOENT is silenced for already-missing files.
- New `CACHE_GET_USAGE` IPC handler walks `{userData}/photosets/`
  to return `{ totalBytes, fileCount }`.
- New **Settings → Storage** page shows total cache disk usage,
  lists uploaded photosets with per-row delete buttons, and a
  bulk "Delete All Uploaded" action with confirmation dialogs.
- Removed the unused `_original` file copy from the image
  processor — these were never uploaded or referenced.

## Testing plan

- New test suite `cache.test.ts` (3 tests): directory walking,
  nonexistent dir, nested subdirectories
- Extended `photoset.test.ts` (4 tests): file path collection,
  disk deletion, ENOENT handling, cross-photoset isolation
- `pnpm run typecheck` passes, lint clean on all changed files

## Security

N/A